### PR TITLE
fix(sql) `wasm__invoke_function_*` returns `int8`.

### DIFF
--- a/src/foreign_data_wrappers/exported_functions.rs
+++ b/src/foreign_data_wrappers/exported_functions.rs
@@ -35,8 +35,8 @@ impl ForeignData for ExportedFunctionsForeignDataWrapper {
         #[inline]
         fn wasm_type_to_pg_type(ty: &Type) -> &str {
             match ty {
-                Type::I32 => "integer",
-                Type::I64 => "bigint",
+                Type::I32 => "int4",
+                Type::I64 => "int8",
                 Type::F32 | Type::F64 => "numeric",
                 Type::V128 => "decimal",
             }

--- a/src/wasm.sql
+++ b/src/wasm.sql
@@ -49,17 +49,17 @@ BEGIN
     EXECUTE format('CREATE OR REPLACE FUNCTION wasm__new_instance(text) RETURNS text AS ''%s'', ''pg_new_instance'' LANGUAGE C STRICT', dylib_pathname);
 
     -- Function `wasm__invoke_function_*`
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_0(text, text) RETURNS int AS ''%s'', ''pg_invoke_function_0'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_1(text, text, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_1'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_2(text, text, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_2'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_3(text, text, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_3'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_4(text, text, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_4'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_5(text, text, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_5'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_6(text, text, bigint, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_6'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_7(text, text, bigint, bigint, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_7'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_8(text, text, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_8'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_9(text, text, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_9'' LANGUAGE C STRICT', dylib_pathname);
-    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_10(text, text, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint) RETURNS int AS ''%s'', ''pg_invoke_function_10'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_0(text, text) RETURNS int8 AS ''%s'', ''pg_invoke_function_0'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_1(text, text, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_1'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_2(text, text, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_2'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_3(text, text, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_3'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_4(text, text, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_4'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_5(text, text, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_5'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_6(text, text, int8, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_6'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_7(text, text, int8, int8, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_7'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_8(text, text, int8, int8, int8, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_8'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_9(text, text, int8, int8, int8, int8, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_9'' LANGUAGE C STRICT', dylib_pathname);
+    EXECUTE format('CREATE OR REPLACE FUNCTION wasm__invoke_function_10(text, text, int8, int8, int8, int8, int8, int8, int8, int8, int8, int8) RETURNS int8 AS ''%s'', ''pg_invoke_function_10'' LANGUAGE C STRICT', dylib_pathname);
 
     RETURN TRUE;
 END;
@@ -101,7 +101,7 @@ BEGIN
         exported_function_generated_outputs := '';
 
         FOR nth IN 1..exported_function.input_arity LOOP
-            exported_function_generated_inputs := exported_function_generated_inputs || format(', CAST($%s AS bigint)', nth);
+            exported_function_generated_inputs := exported_function_generated_inputs || format(', CAST($%s AS int8)', nth);
         END LOOP;
 
         IF length(exported_function.outputs) > 0 THEN

--- a/tests/sql/wasm_new_instance.expected_output
+++ b/tests/sql/wasm_new_instance.expected_output
@@ -6,15 +6,15 @@ id|wasm_file
 fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|%cwd%/tests/wasm/tests.wasm
 (1 row)
 instance_id|name|inputs|outputs
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i64_i64|bigint|bigint
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|string||integer
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i64_i64|int8|int8
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|string||int4
 fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|f64_f64|numeric|numeric
 fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|f32_f32|numeric|numeric
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|bool_casted_to_i32||integer
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i32_i32|integer|integer
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|arity_0||integer
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|sum|integer,integer|integer
-fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i32_i64_f32_f64_f64|integer,bigint,numeric,numeric|numeric
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|bool_casted_to_i32||int4
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i32_i32|int4|int4
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|arity_0||int4
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|sum|int4,int4|int4
+fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|i32_i64_f32_f64_f64|int4,int8,numeric,numeric|numeric
 fcbbe7f2-0875-5f28-83ff-0c5ea9dacd15|void||
 (10 rows)
 ROLLBACK


### PR DESCRIPTION
Those functions were returning `int4` instead of `int8` (which is the
generic bit representation we use to represent all values for the moment).

Also, this patch replaces `integer` and `bigint`, resp. by `int4` and
`int8`. It's the same but more clear.